### PR TITLE
s/taurus/gemd/g

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,23 @@ We have adopted the following style guidelines:
    * Table rows have to be crammed into a single line
    * One sentence can be spread over multiple source lines if it is long
 
+## Building the Docs Locally
+
+Built with [mkdocs](https://www.mkdocs.org/#mkdocs)
+
+You'll need a working python environment to get started.
+
+```
+pip install mkdocs
+```
+
+To build the static site in `./site`:
+```
+mkdocs build
+```
+
+To serve the site, with live reloading:
+```
+mkdocs serve
+```
+This will be served at localhost:8000 by default

--- a/README.md
+++ b/README.md
@@ -1,22 +1,6 @@
-# Taurus data model documentation
+# GEMD Documentation
 
-Deployed to [https://citrineinformatics.github.io/taurus-documentation/](https://citrineinformatics.github.io/taurus-documentation/).
-Built with [mkdocs](https://www.mkdocs.org/#mkdocs)
+GEMD stands for Generalized Expression of Materials Data (or Graph Encoding of Materials Data, if you prefer). It's an open source format developed by the fine folks at Citrine Informatics. 
 
-You'll need a working python environment, with pip.
-This comes by default if you install python with homebrew. 
+The easiest way to read these docs is here:[https://citrineinformatics.github.io/gemd-docs](https://citrineinformatics.github.io/gemd-docs).
 
-```
-pip install mkdocs
-```
-
-To build the static site in `./site`:
-```
-mkdocs build
-```
-
-To serve the site, with live reloading:
-```
-mkdocs serve
-```
-This will be served at localhost:8000 by default

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GEMD Documentation
 
-GEMD stands for Generalized Expression of Materials Data (or Graph Encoding of Materials Data, if you prefer). It's an open source format developed by the fine folks at Citrine Informatics. 
+GEMD stands for Generalized Expression of Materials Data. It's an open source format developed by the fine folks at Citrine Informatics. 
 
 The easiest way to read these docs is here:[https://citrineinformatics.github.io/gemd-docs](https://citrineinformatics.github.io/gemd-docs).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# Taurus Data Model Documentation
+# GEMD Documentation
 
-This is the next major data model developed by Citrine, codename `taurus`.
+GEMD stands for Generalized Expression of Materials Data (or Graph Encoding of Materials Data, if you prefer). It's an open source format initially developed by the fine folks at Citrine Informatics. 
 
 The model links together materials, the processes that produced them, and the measurements that characterize them.
 This facilitates the backwards traversal from a measurement to the material on which it was performed to the process by which it was produced to the materials which were used in that process. 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # GEMD Documentation
 
-GEMD stands for Generalized Expression of Materials Data (or Graph Encoding of Materials Data, if you prefer). It's an open source format initially developed by the fine folks at Citrine Informatics. 
+GEMD stands for Generalized Expression of Materials Data. It's an open source format initially developed by the fine folks at Citrine Informatics. 
 
 The model links together materials, the processes that produced them, and the measurements that characterize them.
 This facilitates the backwards traversal from a measurement to the material on which it was performed to the process by which it was produced to the materials which were used in that process. 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,9 +1,13 @@
 # FAQ
 
 It's not you; it's us.
-Taurus is not a simple representation, and
+GEMD is not a simple representation, and
 we frequently get questions about how to use it to represent certain kinds of data.
 This page attempts to answer some of those questions.
+
+## How do you pronounce GEMD?
+
+This has been a matter of some debate. Both /jemd/ and /jem-dee/ are in common use. 
 
 ## I'm following the documentation, but still having validation problems when using the Citrine Platform.
 
@@ -71,3 +75,7 @@ We strongly encourage documenting all templates, given both how important they a
 This is a place to put pieces of information that may be important to understanding this particular piece of data but do not naturally fit in the other fields.
 This might include an annotation about something unusual about this particular sample.
 Notes normally contain information that is useful for a human but would not be useful in training a machine learning model.
+
+## I found a reference to something called "taurus" - what is that?
+
+"Taurus" was the codename for GEMD when we first started work. We're in the process of migrating everying over to GEMD, but names can be surprisingly sticky.  

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -78,4 +78,4 @@ Notes normally contain information that is useful for a human but would not be u
 
 ## I found a reference to something called "taurus" - what is that?
 
-"Taurus" was the codename for GEMD when we first started work. We're in the process of migrating everying over to GEMD, but names can be surprisingly sticky.  
+"Taurus" was the codename for GEMD when we first started work. We're in the process of migrating everying over to GEMD, but names can be surprisingly persistent.  

--- a/docs/high-level-overview.md
+++ b/docs/high-level-overview.md
@@ -1,7 +1,7 @@
 # High Level Overview
 
 ## How is data stored
-GEMD stands for Generalized Expression of Materials Data (or Graph Encoding of Materials Data, if you prefer). It's an open source format initially developed by the fine folks at Citrine Informatics. 
+GEMD stands for Generalized Expression of Materials Data. It's an open source format initially developed by the fine folks at Citrine Informatics. 
 
 GEMD stores data via interconnected Data Objects, representing Specs and Runs of Materials, Processing steps, Measurements, and Ingredient information.
 This format is graphical rather than tabular.

--- a/docs/high-level-overview.md
+++ b/docs/high-level-overview.md
@@ -1,13 +1,13 @@
 # High Level Overview
 
 ## How is data stored
-We have given this format the codename `taurus`.
+GEMD stands for Generalized Expression of Materials Data (or Graph Encoding of Materials Data, if you prefer). It's an open source format initially developed by the fine folks at Citrine Informatics. 
 
-Taurus stores data via interconnected Data Objects, representing Specs and Runs of Materials, Processing steps, Measurements, and Ingredient information.
+GEMD stores data via interconnected Data Objects, representing Specs and Runs of Materials, Processing steps, Measurements, and Ingredient information.
 This format is graphical rather than tabular.
 It will support a JSON-based serialization, like the
 [PIF](http://citrineinformatics.github.io/pif-documentation/), but with links as references rather than nested objects (i.e. subsystems).
-Conversely, there are many new ideas that exist in taurus that are not captured by the PIF, including:
+Conversely, there are many new ideas that exist in GEMD that are not captured by the PIF, including:
 
 * Process history and process order, including the input materials to process steps
 * Conditions that are shared between properties
@@ -17,7 +17,7 @@ Conversely, there are many new ideas that exist in taurus that are not captured 
 
 ## How are Data Objects defined?
 
-There are four categories of Data Objects in Taurus: Materials, Processes, Measurements, and Ingredients.
+There are four categories of Data Objects in GEMD: Materials, Processes, Measurements, and Ingredients.
 These represent real world objects in the development of materials.
 The 4 categories of Data Objects can only be linked in specific ways, for example, a Process Object can only be linked to one or many Material Objects as its input, more details are explained in Table1.
 Each Object can be represented in 3 different states, these states are defined below, they are Template, Spec, and Run.
@@ -60,7 +60,7 @@ Each Attribute has specified fields that are required or optional as defined in 
 
 ## How are States defined?
 There are 3 main states in which Data Objects exist: Templates, Spec, and Run.
-Taurus distinguishes between the generalization of what might be done (Template), the intent to do something (Spec), and the actual result of doing it (Run).
+GEMD distinguishes between the generalization of what might be done (Template), the intent to do something (Spec), and the actual result of doing it (Run).
 
 > As an example, one can have a Template for a Process Object defined as “sinter at {temperature} for {time} in kiln {id}”.
 This would be the Template used for a Spec of a kiln process used in the production of alumina.
@@ -80,7 +80,7 @@ Field | Required/Optional | Quantity Possible
 *Table2:* Defines the possible fields in all Data Objects and Attributes in all states
 
 ## Templates
-Templates are generalizations of Data Objects used to standardize data in Taurus.
+Templates are generalizations of Data Objects used to standardize data in GEMD.
 Templates are used at write time to validate data and at read time to associate groups of information together.
 Each Spec and Run Object or Attribute (excluding Ingredient Objects and Metadata Attributes) requires a linked Template to support this read and write time association and validation respectively.
 
@@ -200,7 +200,7 @@ Field | Required/Optional | Quantity Possible | Spec or Run
 
 *Table7*: Shows the fields available for Material, Measurement, and Process Objects in the Spec and Run contexts.
 
-Ingredient Objects are treated a little differently from the other Objects in taurus because they are mainly used to annotate a Material with information related to its usage in a Process.
+Ingredient Objects are treated a little differently from the other Objects in GEMD because they are mainly used to annotate a Material with information related to its usage in a Process.
 Note that constraints on `name` and `labels` follow from the `allowed_names` and `allowed_labels` fields of the Process Template.
 Table8 below identifies all the fields available in Ingredient Objects for both Specs and Runs.
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -1,7 +1,7 @@
-# Taurus Philosophy
+# GEMD Philosophy
 
 ## Scope
-Taurus records physical and contextual information about materials and chemicals.
+GEMD records physical and contextual information about materials and chemicals.
 This includes:
 
  - Physical properties of materials and chemicals
@@ -10,11 +10,11 @@ This includes:
  - A controlled vocabulary for domain concepts like "vapor pressure" and "universal testing machine"
 
 ## Objective
-Taurus enables information reuse and supports a material and chemicals system of record.
+GEMD enables information reuse and supports a material and chemicals system of record.
 
 ## Guiding principles
 
-#### Taurus does not define a controlled vocabulary
+#### GEMD does not define a controlled vocabulary
 
 It is not the place of the data format to say "Bandgap" instead of "band gap" or "Young's modulus" instead of "Young modulus".
 [Objects](../specification/objects) and
@@ -24,11 +24,11 @@ which can be used to define controlled vocabularies in data.
 
 #### Validations define a controlled vocabulary
 
-Taurus captures validation in the form of
+GEMD captures validation in the form of
 [Attribute Templates](../specification/attribute-templates) and
 [Object Templates](../specification/object-templates).
 These same objects serve to define a controlled vocabulary of domain concepts.
-The way that taurus indicates that a property is a "vapor pressure" vs an "ambient pressure" vs
+The way that GEMD indicates that a property is a "vapor pressure" vs an "ambient pressure" vs
 a "pressure applied on the horizontal face" is by defining templates for each of those concepts and assigning
 those templates to their corresponding properties.
 
@@ -66,7 +66,7 @@ This is particularly true for implementations that control the generation of tem
 #### Process is a first-class citizen
 
 The same stuff processed in different ways results in different materials, so the process by which a material was created belongs on equal footing with the material itself.
-In taurus, they are in a 1:1 correspondence with each other: every material object has a process object that produced it.
+In GEMD, they are in a 1:1 correspondence with each other: every material object has a process object that produced it.
 It is required because a material cannot be described without describing its process.
 
 #### Multiple authors can contribute to the history of a material
@@ -83,9 +83,9 @@ The objects are linked in a chronological order from oldest to most recent.
 
 But if we try sometimes, we record what we'll need later.
 
-Taurus distinguishes between the intent to do something (a Spec) and the reality of what happened (a Run).
+GEMD distinguishes between the intent to do something (a Spec) and the reality of what happened (a Run).
 Further, a single intent can be realized multiple times.
-This lets taurus capture both systematic and random errors.
+This lets GEMD capture both systematic and random errors.
 It also allows for the definition of intent to precede generation of physical artifacts, supporting information hand-offs to experimental groups.
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Taurus Documentation
+site_name: GEMD Documentation
 theme: readthedocs
 markdown_extensions:
     - toc:


### PR DESCRIPTION
- Purge references to "taurus" from the docs. 
- Add record to the FAQ to clarify why someone might find a reference to taurus somewhere
- Add record to the FAQ to clarify how to pronounce GEMD

Leading question: 
Is GEMD a name, such that sentences like 'GEMD expresses such and such' are grammatical? 
OR 
Is GEMD an acronym, such that we should be saying clumsy things like 'The GEMD model expresses such and such'?

Next Steps: 
1. Rename this repository to "gemd-docs" (github handles redirects transparently, so nothing should break)
2. Merge this PR