### PR TITLE
Changing rounding of Uniform_Integer example

### DIFF
--- a/docs/specification/value-types.md
+++ b/docs/specification/value-types.md
@@ -148,12 +148,12 @@ In order to be valid, the entirety of the distribution must fall within the boun
 
 ##### Example
 
-A value field read off a digital display with 3 decimal points.
+A value field recorded from a digital display reading "0.245".
 ```json
 {
     "type" : "uniform_integer",
-    "lower_bound": 246,
-    "upper_bound": 255
+    "lower_bound": 0.2445,
+    "upper_bound": 0.2554
 }
 ```
 

--- a/docs/specification/value-types.md
+++ b/docs/specification/value-types.md
@@ -148,12 +148,12 @@ In order to be valid, the entirety of the distribution must fall within the boun
 
 ##### Example
 
-A value field recorded from a digital display recording a number of counts (e.g., Geiger counter).
+A value field recorded from a digital display recording an approximate number of counts (e.g. Geiger counter reading "250").
 ```json
 {
     "type" : "uniform_integer",
-    "lower_bound": 246,
-    "upper_bound": 255
+    "lower_bound": 245,
+    "upper_bound": 254
 }
 ```
 

--- a/docs/specification/value-types.md
+++ b/docs/specification/value-types.md
@@ -148,7 +148,7 @@ In order to be valid, the entirety of the distribution must fall within the boun
 
 ##### Example
 
-A value field recorded from a digital display reading "0.245".
+A value field recorded from a digital display recording a number of counts (e.g., Geiger counter).
 ```json
 {
     "type" : "uniform_integer",

--- a/docs/specification/value-types.md
+++ b/docs/specification/value-types.md
@@ -152,8 +152,8 @@ A value field recorded from a digital display recording a number of counts (e.g.
 ```json
 {
     "type" : "uniform_integer",
-    "lower_bound": 0.2445,
-    "upper_bound": 0.2554
+    "lower_bound": 246,
+    "upper_bound": 255
 }
 ```
 


### PR DESCRIPTION
My impression is that standard rounding rules apply to equipment, so I updated the example to make more sense to _me_, at least.