### PR TITLE
Testing change

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ markdown_extensions:
     - toc:
         baselevel: 1
         toc_depth: "2-3"
-        permalink: "#"
+        permalink: True
 
 extra:
     version: 0.1


### PR DESCRIPTION
I can't replicate locally ⚠️, but documentation (https://python-markdown.github.io/extensions/toc/#usage, https://www.mkdocs.org/user-guide/configuration/) suggest ⚠️ alternate values of "permalink" that might go deeper in the header hierarchy.

My goal is to show 2 layers deep, so we can provide direct links to the definitions of "Material History" and "Recipe" in the new Material History Help Modules.