### PR TITLE
Fixing Object Spec require Object Templates statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# IDE files
+.idea
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/docs/high-level-overview.md
+++ b/docs/high-level-overview.md
@@ -182,7 +182,7 @@ It also includes units for real (i.e. continuous) values.
 
 
 ### Data Object Specs and Runs
-Object Specs require an associated Object Template that bounds the valid units and values of the Attributes on the Spec.
+Object Specs may have an associated Object Template that bounds the valid units and values of the Attributes on the Spec.
 
 With the linking of Specs to Runs, Runs inherit associated Templates through Specs.
 For example, Process Runs associated with a Process Spec inherit the Template associated with the Spec, and their Attributes are thus also constrained by the Template.


### PR DESCRIPTION
Suggesting to update the statement:

`Object Specs require an associated Object Template that bounds the valid units and values of the Attributes on the Spec.`

 to say "may have an associated Object Template ... " as Object Templates are not required for Object Specs.

Also added an IDE section to the .gitignore with .idea (IntelliJ) 