### PR TITLE
Change Actions tests to required

### DIFF
--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Initialize the environment
-        continue-on-error: true
         uses: ./.github/actions/initialize
       - name: Build Docs
-        continue-on-error: true
         run: mkdocs build --strict --verbose

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -11,6 +11,7 @@ jobs:
     name: Check docs for warnings
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Initialize the environment
         uses: ./.github/actions/initialize
       - name: Build Docs


### PR DESCRIPTION
This PR modifies the GitHub Actions versions of the repository checks to required (as opposed to optional).  These should now pass as the main archive now contains an initialize action (as opposed to only the branch to be merged).

If this passes and deploys as expected, a third PR in the series will remove Travis configuration from the repository and remove the gate from the repository settings.